### PR TITLE
Update dependabot shedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     groups:
       minors-and-patches:
         update-types:
@@ -12,4 +12,4 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'


### PR DESCRIPTION
Поскольку сейчас каждое слияние в main катится в testing, то нет смысла каждый день катить обновления пакетов каждый день.